### PR TITLE
refactor(typed-arrow-dyn)!: offload nullability enforcement to Arrow and remove policy/eager checks

### DIFF
--- a/typed-arrow-dyn/src/dyn_builder.rs
+++ b/typed-arrow-dyn/src/dyn_builder.rs
@@ -13,9 +13,6 @@ pub trait DynColumnBuilder: Send {
     /// The Arrow logical type this builder produces.
     fn data_type(&self) -> &DataType;
 
-    /// Whether this column allows nulls according to the schema `Field`.
-    fn is_nullable(&self) -> bool;
-
     /// Append a null value.
     fn append_null(&mut self);
 

--- a/typed-arrow-dyn/src/error.rs
+++ b/typed-arrow-dyn/src/error.rs
@@ -15,6 +15,19 @@ pub enum DynError {
         got: usize,
     },
 
+    /// Post-build nullability violation detected by the validator.
+    #[error("nullability violation at column {col} ({path}) index {index}: {message}")]
+    Nullability {
+        /// Top-level column index where the violation occurred.
+        col: usize,
+        /// Dot-annotated path to the offending field (e.g., "struct_field.child[]").
+        path: String,
+        /// Row or value index where the violation was found.
+        index: usize,
+        /// Message describing the violation.
+        message: String,
+    },
+
     /// A cell's Rust value did not match the target Arrow DataType for a column.
     #[error("type mismatch at column {col}: expected {expected:?}")]
     TypeMismatch {

--- a/typed-arrow-dyn/src/factory.rs
+++ b/typed-arrow-dyn/src/factory.rs
@@ -989,8 +989,8 @@ pub fn new_dyn_builder(dt: &DataType) -> Box<dyn DynColumnBuilder> {
                 b::FixedSizeBinaryDictionaryBuilder::<t::UInt64Type>::new(*w),
             ),
             // Primitive dictionary values (numeric & float). Use the minimal trait object wrapper.
-            (k, v) if new_prim_dict_inner(k, v).is_some() => new_prim_dict_inner(k, v).unwrap(),
-            _ => Inner::Null(b::NullBuilder::new()),
+            (k, v) => new_prim_dict_inner(k, v)
+                .unwrap_or_else(|| Inner::Null(b::NullBuilder::new())),
         },
         DataType::Struct(fields) => {
             let children = fields

--- a/typed-arrow-dyn/src/nested.rs
+++ b/typed-arrow-dyn/src/nested.rs
@@ -41,24 +41,8 @@ impl StructCol {
         }
         for (idx, (child, cell)) in self.children.iter_mut().zip(cells.into_iter()).enumerate() {
             match cell {
-                None => {
-                    if !child.is_nullable() {
-                        return Err(DynError::Append {
-                            col: idx,
-                            message: "null not allowed for non-nullable struct field".into(),
-                        });
-                    }
-                    child.append_null();
-                }
-                Some(v) => {
-                    if matches!(v, DynCell::Null) && !child.is_nullable() {
-                        return Err(DynError::Append {
-                            col: idx,
-                            message: "null not allowed for non-nullable struct field".into(),
-                        });
-                    }
-                    child.append_dyn(v).map_err(|e| e.at_col(idx))?;
-                }
+                None => child.append_null(),
+                Some(v) => child.append_dyn(v).map_err(|e| e.at_col(idx))?,
             }
         }
         self.validity.append(true);
@@ -99,22 +83,8 @@ impl ListCol {
         let mut added = 0i32;
         for it in items.into_iter() {
             match it {
-                None => {
-                    if !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_null();
-                }
-                Some(v) => {
-                    if matches!(v, DynCell::Null) && !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_dyn(v)?;
-                }
+                None => self.child.append_null(),
+                Some(v) => self.child.append_dyn(v)?,
             }
             added += 1;
         }
@@ -160,22 +130,8 @@ impl LargeListCol {
         let mut added = 0i64;
         for it in items.into_iter() {
             match it {
-                None => {
-                    if !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_null();
-                }
-                Some(v) => {
-                    if matches!(v, DynCell::Null) && !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_dyn(v)?;
-                }
+                None => self.child.append_null(),
+                Some(v) => self.child.append_dyn(v)?,
             }
             added += 1;
         }
@@ -234,22 +190,8 @@ impl FixedSizeListCol {
         }
         for it in items.into_iter() {
             match it {
-                None => {
-                    if !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_null();
-                }
-                Some(v) => {
-                    if matches!(v, DynCell::Null) && !self.child.is_nullable() {
-                        return Err(DynError::Builder {
-                            message: "null not allowed for non-nullable list item".into(),
-                        });
-                    }
-                    self.child.append_dyn(v)?;
-                }
+                None => self.child.append_null(),
+                Some(v) => self.child.append_dyn(v)?,
             }
         }
         self.validity.append(true);

--- a/typed-arrow-dyn/src/rows.rs
+++ b/typed-arrow-dyn/src/rows.rs
@@ -41,8 +41,8 @@ impl DynRow {
         let mut cells = self.0.into_iter();
         for (i, b) in cols.iter_mut().enumerate() {
             match cells.next() {
-                // End of iterator (shouldn't happen due to arity check), treat as null
-                None => b.append_null(),
+                // End of iterator should be impossible due to arity check
+                None => unreachable!("cells length pre-checked to match columns"),
                 Some(None) => b.append_null(),
                 Some(Some(v)) => {
                     b.append_dyn(v).map_err(|e| e.at_col(i))?;


### PR DESCRIPTION
- Remove NullabilityPolicy and internal post-build validator
- Remove DynColumnBuilder::is_nullable()
- Simplify new_dyn_builder(dt) signature and propagate usage
- Drop append-time nullability checks in DynRow and nested builders
- Arrow enforces non-nullable fields/children at array/RecordBatch construction
- Update tests to assert failures at finish via Arrow panics

BREAKING CHANGE: DynColumnBuilder::is_nullable() removed; new_dyn_builder signature changed to new_dyn_builder(&DataType). Append-time nullability validation no longer occurs; violations surface during finish via Arrow.