### PR TITLE
Struct-like views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ version = "0.4.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
+ "arrow-data",
  "arrow-schema",
  "half",
  "typed-arrow-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -392,6 +401,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -416,6 +436,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
+ "thiserror 2.0.17",
  "typed-arrow-derive",
 ]
 
@@ -435,7 +456,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-arrow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ arrow-schema = { version = "56" }
 arrow-buffer = { version = "56" }
 arrow-data = { version = "56" }
 half = "2"
+thiserror = "2.0"
 
 [[example]]
 name = "12_ext_hooks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,60 @@ name = "typed_arrow"
 path = "src/lib.rs"
 
 [features]
-default = ["derive"]
+default = ["derive", "views"]
 derive = ["dep:typed-arrow-derive"]
 ext-hooks = ["derive", "typed-arrow-derive/ext-hooks"]
+views = ["derive"]
 
 [dependencies]
 typed-arrow-derive = { path = "typed-arrow-derive", version = "0.4.0", optional = true, package = "typed-arrow-derive" }
 arrow-array = { version = "56" }
 arrow-schema = { version = "56" }
 arrow-buffer = { version = "56" }
+arrow-data = { version = "56" }
 half = "2"
 
 [[example]]
 name = "12_ext_hooks"
 path = "examples/12_ext_hooks.rs"
 required-features = ["ext-hooks"]
+
+[[example]]
+name = "13_record_batch_views"
+path = "examples/13_record_batch_views.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views"
+path = "tests/record_batch_views.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_comprehensive"
+path = "tests/record_batch_views_comprehensive.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_dictionary"
+path = "tests/record_batch_views_dictionary.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_lists"
+path = "tests/record_batch_views_lists.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_maps"
+path = "tests/record_batch_views_maps.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_temporal"
+path = "tests/record_batch_views_temporal.rs"
+required-features = ["views"]
+
+[[test]]
+name = "record_batch_views_union"
+path = "tests/record_batch_views_union.rs"
+required-features = ["views"]

--- a/examples/13_record_batch_views.rs
+++ b/examples/13_record_batch_views.rs
@@ -1,0 +1,130 @@
+//! Showcase: Zero-copy views over RecordBatch rows.
+//!
+//! The derive macro automatically generates `{Name}View<'a>` structs and
+//! `{Name}Views<'a>` iterators that provide borrowed access to RecordBatch
+//! data without copying.
+
+use arrow_array::RecordBatch;
+use typed_arrow::prelude::*;
+
+#[derive(typed_arrow::Record)]
+struct Product {
+    id: i64,
+    name: String,
+    price: f64,
+    in_stock: Option<bool>,
+}
+
+#[derive(typed_arrow::Record)]
+struct Coordinates {
+    lat: f64,
+    lon: f64,
+}
+
+#[derive(typed_arrow::Record)]
+struct Location {
+    city: String,
+    coords: Option<Coordinates>,
+}
+
+fn main() -> Result<(), typed_arrow::schema::SchemaError> {
+    println!("=== Example 1: Simple flat record views ===\n");
+    flat_record_example()?;
+
+    println!("\n=== Example 2: Nested struct views ===\n");
+    nested_record_example()?;
+
+    Ok(())
+}
+
+fn flat_record_example() -> Result<(), typed_arrow::schema::SchemaError> {
+    // Build rows
+    let rows = vec![
+        Product {
+            id: 1,
+            name: "Widget".into(),
+            price: 9.99,
+            in_stock: Some(true),
+        },
+        Product {
+            id: 2,
+            name: "Gadget".into(),
+            price: 19.99,
+            in_stock: None,
+        },
+        Product {
+            id: 3,
+            name: "Doohickey".into(),
+            price: 14.50,
+            in_stock: Some(false),
+        },
+    ];
+
+    // Build RecordBatch
+    let mut b = <Product as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    println!("RecordBatch has {} rows", batch.num_rows());
+
+    // Create zero-copy views over the batch using the convenient API
+    let views = batch.iter_views::<Product>()?;
+
+    println!("Products in stock:");
+    for view in views.try_flatten()? {
+        // All fields are borrowed references - no copying!
+        // Strings are &str, primitives are copied (they're small)
+        match view.in_stock {
+            Some(true) => println!("  #{}: {} - ${:.2}", view.id, view.name, view.price),
+            Some(false) => {}
+            None => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn nested_record_example() -> Result<(), typed_arrow::schema::SchemaError> {
+    let locations = vec![
+        Location {
+            city: "New York".into(),
+            coords: Some(Coordinates {
+                lat: 40.7128,
+                lon: -74.0060,
+            }),
+        },
+        Location {
+            city: "Unknown City".into(),
+            coords: None,
+        },
+        Location {
+            city: "San Francisco".into(),
+            coords: Some(Coordinates {
+                lat: 37.7749,
+                lon: -122.4194,
+            }),
+        },
+    ];
+
+    let mut b = <Location as BuildRows>::new_builders(locations.len());
+    b.append_rows(locations);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    println!("RecordBatch has {} rows", batch.num_rows());
+
+    // Iterate with zero-copy views using the convenient API
+    let views = batch.iter_views::<Location>()?;
+
+    println!("Locations with coordinates:");
+    for view in views.try_flatten()? {
+        print!("  {}: ", view.city);
+        match view.coords {
+            Some(coords) => println!("({:.4}, {:.4})", coords.lat, coords.lon),
+            None => println!("(no coordinates)"),
+        }
+    }
+
+    Ok(())
+}

--- a/src/bridge/binary.rs
+++ b/src/bridge/binary.rs
@@ -55,10 +55,6 @@ impl ArrowBindingView for Vec<u8> {
         }
         Ok(array.value(index))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 // FixedSizeBinary: [u8; N]
@@ -105,10 +101,6 @@ impl<const N: usize> super::ArrowBindingView for [u8; N] {
             });
         }
         Ok(array.value(index))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -187,9 +179,5 @@ impl ArrowBindingView for LargeBinary {
             });
         }
         Ok(array.value(index))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/decimals.rs
+++ b/src/bridge/decimals.rs
@@ -84,10 +84,6 @@ impl<const P: u8, const S: i8> ArrowBindingView for Decimal128<P, S> {
         }
         Ok(Decimal128::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Fixed-precision decimal stored in 256 bits.
@@ -162,9 +158,5 @@ impl<const P: u8, const S: i8> ArrowBindingView for Decimal256<P, S> {
             });
         }
         Ok(Decimal256::new(array.value(index)))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/intervals.rs
+++ b/src/bridge/intervals.rs
@@ -77,10 +77,6 @@ impl ArrowBindingView for IntervalYearMonth {
         }
         Ok(IntervalYearMonth::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Interval with unit `DayTime` (packed days and milliseconds).
@@ -149,10 +145,6 @@ impl ArrowBindingView for IntervalDayTime {
         }
         Ok(IntervalDayTime::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Interval with unit `MonthDayNano` (packed months, days, and nanoseconds).
@@ -220,9 +212,5 @@ impl ArrowBindingView for IntervalMonthDayNano {
             });
         }
         Ok(IntervalMonthDayNano::new(array.value(index)))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/intervals.rs
+++ b/src/bridge/intervals.rs
@@ -3,11 +3,13 @@
 use arrow_array::{
     builder::PrimitiveBuilder,
     types::{IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType},
-    PrimitiveArray,
+    Array, PrimitiveArray,
 };
 use arrow_schema::{DataType, IntervalUnit};
 
 use super::ArrowBinding;
+#[cfg(feature = "views")]
+use super::ArrowBindingView;
 
 /// Interval with unit `YearMonth` (i32 months since epoch).
 pub struct IntervalYearMonth(i32);
@@ -48,6 +50,36 @@ impl ArrowBinding for IntervalYearMonth {
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+#[cfg(feature = "views")]
+impl ArrowBindingView for IntervalYearMonth {
+    type Array = PrimitiveArray<IntervalYearMonthType>;
+    type View<'a> = IntervalYearMonth;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        Ok(IntervalYearMonth::new(array.value(index)))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }
 
@@ -93,6 +125,36 @@ impl ArrowBinding for IntervalDayTime {
     }
 }
 
+#[cfg(feature = "views")]
+impl ArrowBindingView for IntervalDayTime {
+    type Array = PrimitiveArray<IntervalDayTimeType>;
+    type View<'a> = IntervalDayTime;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        Ok(IntervalDayTime::new(array.value(index)))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
+    }
+}
+
 /// Interval with unit `MonthDayNano` (packed months, days, and nanoseconds).
 pub struct IntervalMonthDayNano(arrow_array::types::IntervalMonthDayNano);
 impl IntervalMonthDayNano {
@@ -132,5 +194,35 @@ impl ArrowBinding for IntervalMonthDayNano {
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+#[cfg(feature = "views")]
+impl ArrowBindingView for IntervalMonthDayNano {
+    type Array = PrimitiveArray<IntervalMonthDayNanoType>;
+    type View<'a> = IntervalMonthDayNano;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        Ok(IntervalMonthDayNano::new(array.value(index)))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }

--- a/src/bridge/lists.rs
+++ b/src/bridge/lists.rs
@@ -1,9 +1,14 @@
 //! `List`, `LargeList`, and `FixedSizeList` bindings.
 
-use arrow_array::builder::{ArrayBuilder, FixedSizeListBuilder, LargeListBuilder, ListBuilder};
+use arrow_array::{
+    builder::{ArrayBuilder, FixedSizeListBuilder, LargeListBuilder, ListBuilder},
+    Array,
+};
 use arrow_schema::{DataType, Field};
 
 use super::ArrowBinding;
+#[cfg(feature = "views")]
+use super::ArrowBindingView;
 
 /// Wrapper denoting an Arrow `ListArray` column with elements of `T`.
 ///
@@ -60,7 +65,11 @@ where
     }
     fn new_builder(_capacity: usize) -> Self::Builder {
         let child = <T as ArrowBinding>::new_builder(0);
-        ListBuilder::new(child)
+        ListBuilder::new(child).with_field(Field::new(
+            "item",
+            <T as ArrowBinding>::data_type(),
+            false,
+        ))
     }
     fn append_value(b: &mut Self::Builder, v: &Self) {
         for it in &v.0 {
@@ -73,6 +82,139 @@ where
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+/// Iterator over views of list elements.
+#[cfg(feature = "views")]
+pub struct ListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new list view from a values array and offset range.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize, end: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the length of the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the list is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> Iterator for ListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<T::View<'a>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let value = T::get_view(self.values_array, self.start);
+            self.start += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ExactSizeIterator for ListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> DoubleEndedIterator for ListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(T::get_view(self.values_array, self.end))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T> ArrowBindingView for List<T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::ListArray;
+    type View<'a> = ListView<'a, T>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(ListView::new(values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }
 
@@ -90,7 +232,11 @@ where
     }
     fn new_builder(_capacity: usize) -> Self::Builder {
         let child = <T as ArrowBinding>::new_builder(0);
-        ListBuilder::new(child)
+        ListBuilder::new(child).with_field(Field::new(
+            "item",
+            <T as ArrowBinding>::data_type(),
+            true,
+        ))
     }
     fn append_value(b: &mut Self::Builder, v: &Self) {
         for it in &v.0 {
@@ -106,6 +252,148 @@ where
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+/// Iterator over views of list elements with nullable items.
+#[cfg(feature = "views")]
+pub struct ListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new nullable list view from a values array and offset range.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize, end: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the length of the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the list is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> Iterator for ListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<Option<T::View<'a>>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let result = if T::is_null(self.values_array, self.start) {
+                Ok(None)
+            } else {
+                T::get_view(self.values_array, self.start).map(Some)
+            };
+            self.start += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ExactSizeIterator for ListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> DoubleEndedIterator for ListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            let result = if T::is_null(self.values_array, self.end) {
+                Ok(None)
+            } else {
+                T::get_view(self.values_array, self.end).map(Some)
+            };
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T> ArrowBindingView for List<Option<T>>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::ListArray;
+    type View<'a> = ListViewNullable<'a, T>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(ListViewNullable::new(values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }
 
@@ -169,6 +457,135 @@ where
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+/// Iterator over views of fixed-size list elements.
+#[cfg(feature = "views")]
+pub struct FixedSizeListView<'a, T, const N: usize>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    current: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> FixedSizeListView<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new fixed-size list view from a values array and start offset.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            current: 0,
+        }
+    }
+
+    /// Get the length of the list (always N).
+    #[inline]
+    pub const fn len(&self) -> usize {
+        N
+    }
+
+    /// Check if the list is empty (true only when N = 0).
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        N == 0
+    }
+
+    /// Get the value at a specific index.
+    ///
+    /// Returns Ok(Some(view)) if the index is valid, Ok(None) if out of bounds,
+    /// or Err if there's an error accessing the view.
+    #[inline]
+    pub fn get(&self, index: usize) -> Result<Option<T::View<'a>>, crate::schema::ViewAccessError> {
+        if index < N {
+            T::get_view(self.values_array, self.start + index).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> Iterator for FixedSizeListView<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<T::View<'a>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current < N {
+            let value = T::get_view(self.values_array, self.start + self.current);
+            self.current += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = N.saturating_sub(self.current);
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> ExactSizeIterator for FixedSizeListView<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        N.saturating_sub(self.current)
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T, const N: usize> ArrowBindingView for FixedSizeList<T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::FixedSizeListArray;
+    type View<'a> = FixedSizeListView<'a, T, N>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let start = index * N;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(FixedSizeListView::new(values_array, start))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }
 
@@ -238,6 +655,148 @@ where
     }
 }
 
+/// Iterator over views of fixed-size list elements with nullable items.
+#[cfg(feature = "views")]
+pub struct FixedSizeListViewNullable<'a, T, const N: usize>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    current: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> FixedSizeListViewNullable<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new nullable fixed-size list view from a values array and start offset.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            current: 0,
+        }
+    }
+
+    /// Get the length of the list (always N).
+    #[inline]
+    pub const fn len(&self) -> usize {
+        N
+    }
+
+    /// Check if the list is empty (true only when N = 0).
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        N == 0
+    }
+
+    /// Get the value at a specific index, returning None if null or out of bounds.
+    ///
+    /// Returns Ok(Some(Some(view))) if valid and non-null, Ok(Some(None)) if null,
+    /// Ok(None) if out of bounds, or Err if there's an error accessing the view.
+    #[inline]
+    pub fn get(
+        &self,
+        index: usize,
+    ) -> Result<Option<Option<T::View<'a>>>, crate::schema::ViewAccessError> {
+        if index < N {
+            let idx = self.start + index;
+            if T::is_null(self.values_array, idx) {
+                Ok(Some(None))
+            } else {
+                T::get_view(self.values_array, idx).map(|v| Some(Some(v)))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> Iterator for FixedSizeListViewNullable<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<Option<T::View<'a>>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current < N {
+            let idx = self.start + self.current;
+            let result = if T::is_null(self.values_array, idx) {
+                Ok(None)
+            } else {
+                T::get_view(self.values_array, idx).map(Some)
+            };
+            self.current += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = N.saturating_sub(self.current);
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T, const N: usize> ExactSizeIterator for FixedSizeListViewNullable<'a, T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        N.saturating_sub(self.current)
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T, const N: usize> ArrowBindingView for FixedSizeListNullable<T, N>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::FixedSizeListArray;
+    type View<'a> = FixedSizeListViewNullable<'a, T, N>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let start = index * N;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(FixedSizeListViewNullable::new(values_array, start))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
+    }
+}
+
 /// Wrapper denoting an Arrow `LargeListArray` column with elements of `T`.
 pub struct LargeList<T>(Vec<T>);
 impl<T> LargeList<T> {
@@ -289,7 +848,11 @@ where
     }
     fn new_builder(_capacity: usize) -> Self::Builder {
         let child = <T as ArrowBinding>::new_builder(0);
-        LargeListBuilder::new(child)
+        LargeListBuilder::new(child).with_field(Field::new(
+            "item",
+            <T as ArrowBinding>::data_type(),
+            false,
+        ))
     }
     fn append_value(b: &mut Self::Builder, v: &Self) {
         for it in &v.0 {
@@ -302,6 +865,139 @@ where
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+/// Iterator over views of large list elements.
+#[cfg(feature = "views")]
+pub struct LargeListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> LargeListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new large list view from a values array and offset range.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize, end: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the length of the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the list is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> Iterator for LargeListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<T::View<'a>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let value = T::get_view(self.values_array, self.start);
+            self.start += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ExactSizeIterator for LargeListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> DoubleEndedIterator for LargeListView<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(T::get_view(self.values_array, self.end))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T> ArrowBindingView for LargeList<T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::LargeListArray;
+    type View<'a> = LargeListView<'a, T>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(LargeListView::new(values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }
 
@@ -319,7 +1015,11 @@ where
     }
     fn new_builder(_capacity: usize) -> Self::Builder {
         let child = <T as ArrowBinding>::new_builder(0);
-        LargeListBuilder::new(child)
+        LargeListBuilder::new(child).with_field(Field::new(
+            "item",
+            <T as ArrowBinding>::data_type(),
+            true,
+        ))
     }
     fn append_value(b: &mut Self::Builder, v: &Self) {
         for it in &v.0 {
@@ -335,5 +1035,147 @@ where
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
         b.finish()
+    }
+}
+
+/// Iterator over views of large list elements with nullable items.
+#[cfg(feature = "views")]
+pub struct LargeListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    values_array: &'a T::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> LargeListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    /// Create a new nullable large list view from a values array and offset range.
+    #[inline]
+    fn new(values_array: &'a T::Array, start: usize, end: usize) -> Self {
+        Self {
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the length of the list.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the list is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> Iterator for LargeListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Item = Result<Option<T::View<'a>>, crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let result = if T::is_null(self.values_array, self.start) {
+                Ok(None)
+            } else {
+                T::get_view(self.values_array, self.start).map(Some)
+            };
+            self.start += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> ExactSizeIterator for LargeListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, T> DoubleEndedIterator for LargeListViewNullable<'a, T>
+where
+    T: ArrowBindingView + 'static,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            let result = if T::is_null(self.values_array, self.end) {
+                Ok(None)
+            } else {
+                T::get_view(self.values_array, self.end).map(Some)
+            };
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl<T> ArrowBindingView for LargeList<Option<T>>
+where
+    T: ArrowBindingView + 'static,
+{
+    type Array = arrow_array::LargeListArray;
+    type View<'a> = LargeListViewNullable<'a, T>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+        let values_array = array
+            .values()
+            .as_any()
+            .downcast_ref::<T::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<T::Array>().to_string(),
+                actual: format!("{:?}", array.values().data_type()),
+                field_name: None,
+            })?;
+        Ok(LargeListViewNullable::new(values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }

--- a/src/bridge/map.rs
+++ b/src/bridge/map.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use arrow_array::{builder::MapBuilder, MapArray};
+use arrow_array::{builder::MapBuilder, Array, MapArray};
 use arrow_schema::{DataType, Field};
 
 use super::ArrowBinding;
@@ -181,7 +181,30 @@ where
         let _ = b.append(false);
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
-        b.finish()
+        use arrow_array::Array;
+        use arrow_data::ArrayData;
+
+        let map_array = b.finish();
+
+        // MapBuilder always creates maps with sorted=false, so we need to manually update it
+        // Get the existing field and create a new DataType with sorted=true
+        let data = map_array.into_data();
+        let (field, _sorted) = match data.data_type() {
+            DataType::Map(f, _) => (f.clone(), true),
+            _ => unreachable!(),
+        };
+
+        // Reconstruct the MapArray with sorted=true flag
+        // All data is copied from the valid MapArray produced by MapBuilder
+        let new_data = ArrayData::builder(DataType::Map(field, true))
+            .len(data.len())
+            .buffers(data.buffers().to_vec())
+            .child_data(data.child_data().to_vec())
+            .nulls(data.nulls().cloned())
+            .build()
+            .expect("MapArray reconstruction should succeed - all data copied from valid array");
+
+        MapArray::from(new_data)
     }
 }
 
@@ -220,6 +243,449 @@ where
         let _ = b.append(false);
     }
     fn finish(mut b: Self::Builder) -> Self::Array {
-        b.finish()
+        use arrow_array::Array;
+        use arrow_data::ArrayData;
+
+        let map_array = b.finish();
+
+        // MapBuilder always creates maps with sorted=false, so we need to manually update it
+        // Get the existing field and create a new DataType with sorted=true
+        let data = map_array.into_data();
+        let (field, _sorted) = match data.data_type() {
+            DataType::Map(f, _) => (f.clone(), true),
+            _ => unreachable!(),
+        };
+
+        // Reconstruct the MapArray with sorted=true flag
+        // All data is copied from the valid MapArray produced by MapBuilder
+        let new_data = ArrayData::builder(DataType::Map(field, true))
+            .len(data.len())
+            .buffers(data.buffers().to_vec())
+            .child_data(data.child_data().to_vec())
+            .nulls(data.nulls().cloned())
+            .build()
+            .expect("MapArray reconstruction should succeed - all data copied from valid array");
+
+        MapArray::from(new_data)
+    }
+}
+
+/// Iterator over views of map entries (key-value pairs).
+#[cfg(feature = "views")]
+pub struct MapView<'a, K, V, const SORTED: bool = false>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    keys_array: &'a <K as super::ArrowBindingView>::Array,
+    values_array: &'a <V as super::ArrowBindingView>::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> MapView<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    fn new(
+        keys_array: &'a <K as super::ArrowBindingView>::Array,
+        values_array: &'a <V as super::ArrowBindingView>::Array,
+        start: usize,
+        end: usize,
+    ) -> Self {
+        Self {
+            keys_array,
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the number of entries in the map.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the map is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> Iterator for MapView<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    type Item = Result<(K::View<'a>, V::View<'a>), crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let result = K::get_view(self.keys_array, self.start).and_then(|key| {
+                V::get_view(self.values_array, self.start).map(|value| (key, value))
+            });
+            self.start += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> ExactSizeIterator for MapView<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<K, V, const SORTED: bool> super::ArrowBindingView for Map<K, V, SORTED>
+where
+    K: ArrowBinding + super::ArrowBindingView + 'static,
+    V: ArrowBinding + super::ArrowBindingView + 'static,
+{
+    type Array = arrow_array::MapArray;
+    type View<'a> = MapView<'a, K, V, SORTED>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+
+        // MapArray entries are stored as a StructArray with "keys" and "values" fields
+        let entries = array.entries();
+        let keys_array = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<<K as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(0).data_type()),
+                field_name: Some("keys"),
+            })?;
+        let values_array = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<<V as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(1).data_type()),
+                field_name: Some("values"),
+            })?;
+
+        Ok(MapView::new(keys_array, values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
+    }
+}
+
+#[cfg(feature = "views")]
+impl<K, V> super::ArrowBindingView for OrderedMap<K, V>
+where
+    K: ArrowBinding + Ord + super::ArrowBindingView + 'static,
+    V: ArrowBinding + super::ArrowBindingView + 'static,
+{
+    type Array = arrow_array::MapArray;
+    type View<'a> = MapView<'a, K, V, true>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+
+        let entries = array.entries();
+        let keys_array = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<<K as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(0).data_type()),
+                field_name: Some("keys"),
+            })?;
+        let values_array = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<<V as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(1).data_type()),
+                field_name: Some("values"),
+            })?;
+
+        Ok(MapView::new(keys_array, values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
+    }
+}
+
+/// Iterator over views of map entries with nullable values.
+#[cfg(feature = "views")]
+pub struct MapViewNullable<'a, K, V, const SORTED: bool = false>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    keys_array: &'a <K as super::ArrowBindingView>::Array,
+    values_array: &'a <V as super::ArrowBindingView>::Array,
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> MapViewNullable<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    fn new(
+        keys_array: &'a <K as super::ArrowBindingView>::Array,
+        values_array: &'a <V as super::ArrowBindingView>::Array,
+        start: usize,
+        end: usize,
+    ) -> Self {
+        Self {
+            keys_array,
+            values_array,
+            start,
+            end,
+        }
+    }
+
+    /// Get the number of entries in the map.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Check if the map is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> Iterator for MapViewNullable<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    type Item = Result<(K::View<'a>, Option<V::View<'a>>), crate::schema::ViewAccessError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            let result = K::get_view(self.keys_array, self.start).and_then(|key| {
+                let value = if V::is_null(self.values_array, self.start) {
+                    Ok(None)
+                } else {
+                    V::get_view(self.values_array, self.start).map(Some)
+                };
+                value.map(|v| (key, v))
+            });
+            self.start += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.start;
+        (remaining, Some(remaining))
+    }
+}
+
+#[cfg(feature = "views")]
+impl<'a, K, V, const SORTED: bool> ExactSizeIterator for MapViewNullable<'a, K, V, SORTED>
+where
+    K: super::ArrowBindingView + 'static,
+    V: super::ArrowBindingView + 'static,
+{
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+#[cfg(feature = "views")]
+impl<K, V, const SORTED: bool> super::ArrowBindingView for Map<K, Option<V>, SORTED>
+where
+    K: ArrowBinding + super::ArrowBindingView + 'static,
+    V: ArrowBinding + super::ArrowBindingView + 'static,
+{
+    type Array = arrow_array::MapArray;
+    type View<'a> = MapViewNullable<'a, K, V, SORTED>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+
+        let entries = array.entries();
+        let keys_array = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<<K as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(0).data_type()),
+                field_name: Some("keys"),
+            })?;
+        let values_array = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<<V as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(1).data_type()),
+                field_name: Some("values"),
+            })?;
+
+        Ok(MapViewNullable::new(keys_array, values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
+    }
+}
+
+#[cfg(feature = "views")]
+impl<K, V> super::ArrowBindingView for OrderedMap<K, Option<V>>
+where
+    K: ArrowBinding + Ord + super::ArrowBindingView + 'static,
+    V: ArrowBinding + super::ArrowBindingView + 'static,
+{
+    type Array = arrow_array::MapArray;
+    type View<'a> = MapViewNullable<'a, K, V, true>;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+        if array.is_null(index) {
+            return Err(crate::schema::ViewAccessError::UnexpectedNull {
+                index,
+                field_name: None,
+            });
+        }
+
+        let offsets = array.value_offsets();
+        let start = offsets[index] as usize;
+        let end = offsets[index + 1] as usize;
+
+        let entries = array.entries();
+        let keys_array = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<<K as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(0).data_type()),
+                field_name: Some("keys"),
+            })?;
+        let values_array = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<<V as super::ArrowBindingView>::Array>()
+            .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
+                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
+                    .to_string(),
+                actual: format!("{:?}", entries.column(1).data_type()),
+                field_name: Some("values"),
+            })?;
+
+        Ok(MapViewNullable::new(keys_array, values_array, start, end))
+    }
+
+    fn is_null(array: &Self::Array, index: usize) -> bool {
+        array.is_null(index)
     }
 }

--- a/src/bridge/map.rs
+++ b/src/bridge/map.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use arrow_array::{builder::MapBuilder, Array, MapArray};
+use arrow_array::{builder::MapBuilder, MapArray};
 use arrow_schema::{DataType, Field};
 
 use super::ArrowBinding;
@@ -392,9 +392,8 @@ where
             .as_any()
             .downcast_ref::<<K as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(0).data_type()),
+                expected: K::data_type(),
+                actual: entries.column(0).data_type().clone(),
                 field_name: Some("keys"),
             })?;
         let values_array = entries
@@ -402,17 +401,12 @@ where
             .as_any()
             .downcast_ref::<<V as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(1).data_type()),
+                expected: V::data_type(),
+                actual: entries.column(1).data_type().clone(),
                 field_name: Some("values"),
             })?;
 
         Ok(MapView::new(keys_array, values_array, start, end))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -454,9 +448,8 @@ where
             .as_any()
             .downcast_ref::<<K as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(0).data_type()),
+                expected: K::data_type(),
+                actual: entries.column(0).data_type().clone(),
                 field_name: Some("keys"),
             })?;
         let values_array = entries
@@ -464,17 +457,12 @@ where
             .as_any()
             .downcast_ref::<<V as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(1).data_type()),
+                expected: V::data_type(),
+                actual: entries.column(1).data_type().clone(),
                 field_name: Some("values"),
             })?;
 
         Ok(MapView::new(keys_array, values_array, start, end))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -535,7 +523,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         if self.start < self.end {
             let result = K::get_view(self.keys_array, self.start).and_then(|key| {
-                let value = if V::is_null(self.values_array, self.start) {
+                use arrow_array::Array;
+                let value = if self.values_array.is_null(self.start) {
                     Ok(None)
                 } else {
                     V::get_view(self.values_array, self.start).map(Some)
@@ -604,9 +593,8 @@ where
             .as_any()
             .downcast_ref::<<K as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(0).data_type()),
+                expected: K::data_type(),
+                actual: entries.column(0).data_type().clone(),
                 field_name: Some("keys"),
             })?;
         let values_array = entries
@@ -614,17 +602,12 @@ where
             .as_any()
             .downcast_ref::<<V as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(1).data_type()),
+                expected: V::data_type(),
+                actual: entries.column(1).data_type().clone(),
                 field_name: Some("values"),
             })?;
 
         Ok(MapViewNullable::new(keys_array, values_array, start, end))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -666,9 +649,8 @@ where
             .as_any()
             .downcast_ref::<<K as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<K as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(0).data_type()),
+                expected: K::data_type(),
+                actual: entries.column(0).data_type().clone(),
                 field_name: Some("keys"),
             })?;
         let values_array = entries
@@ -676,16 +658,11 @@ where
             .as_any()
             .downcast_ref::<<V as super::ArrowBindingView>::Array>()
             .ok_or_else(|| crate::schema::ViewAccessError::TypeMismatch {
-                expected: std::any::type_name::<<V as super::ArrowBindingView>::Array>()
-                    .to_string(),
-                actual: format!("{:?}", entries.column(1).data_type()),
+                expected: V::data_type(),
+                actual: entries.column(1).data_type().clone(),
                 field_name: Some("values"),
             })?;
 
         Ok(MapViewNullable::new(keys_array, values_array, start, end))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -74,9 +74,6 @@ pub trait ArrowBindingView {
         array: &Self::Array,
         index: usize,
     ) -> Result<Self::View<'_>, crate::schema::ViewAccessError>;
-
-    /// Check if the value at the given index is null.
-    fn is_null(array: &Self::Array, index: usize) -> bool;
 }
 
 mod binary;
@@ -87,6 +84,7 @@ mod intervals;
 mod lists;
 mod map;
 mod null_type;
+mod option;
 mod primitives;
 mod record_struct;
 mod strings;

--- a/src/bridge/option.rs
+++ b/src/bridge/option.rs
@@ -1,0 +1,46 @@
+//! ArrowBindingView implementation for Option<T>.
+//!
+//! This module provides view support for nullable types, allowing `Option<T>` to have
+//! `View = Option<T::View>` while non-nullable types return errors on null values.
+
+#[cfg(feature = "views")]
+use super::ArrowBindingView;
+
+/// Implement ArrowBindingView for Option<T> where T implements ArrowBindingView.
+///
+/// This allows nullable fields to properly handle null values by returning Ok(None)
+/// instead of Err(UnexpectedNull), making the type system enforce correct null handling.
+#[cfg(feature = "views")]
+impl<T> ArrowBindingView for Option<T>
+where
+    T: ArrowBindingView,
+{
+    type Array = T::Array;
+    type View<'a>
+        = Option<T::View<'a>>
+    where
+        Self: 'a;
+
+    fn get_view(
+        array: &Self::Array,
+        index: usize,
+    ) -> Result<Self::View<'_>, crate::schema::ViewAccessError> {
+        use arrow_array::Array;
+
+        if index >= array.len() {
+            return Err(crate::schema::ViewAccessError::OutOfBounds {
+                index,
+                len: array.len(),
+                field_name: None,
+            });
+        }
+
+        // For nullable types, null is valid data
+        if array.is_null(index) {
+            return Ok(None);
+        }
+
+        // Delegate to the inner type's get_view
+        T::get_view(array, index).map(Some)
+    }
+}

--- a/src/bridge/primitives.rs
+++ b/src/bridge/primitives.rs
@@ -62,10 +62,6 @@ macro_rules! impl_primitive_binding {
                 }
                 Ok(array.value(index))
             }
-
-            fn is_null(array: &Self::Array, index: usize) -> bool {
-                array.is_null(index)
-            }
         }
     };
 }
@@ -126,10 +122,6 @@ impl ArrowBindingView for f16 {
         }
         Ok(array.value(index))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 // Boolean
@@ -176,9 +168,5 @@ impl ArrowBindingView for bool {
             });
         }
         Ok(array.value(index))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/record_struct.rs
+++ b/src/bridge/record_struct.rs
@@ -78,8 +78,4 @@ where
         }
         <T as StructView>::view_at(array, index)
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        <T as StructView>::is_null_at(array, index)
-    }
 }

--- a/src/bridge/strings.rs
+++ b/src/bridge/strings.rs
@@ -55,10 +55,6 @@ impl ArrowBindingView for String {
         }
         Ok(array.value(index))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Wrapper denoting Arrow `LargeUtf8` values. Use when individual strings can be
@@ -144,9 +140,5 @@ impl ArrowBindingView for LargeUtf8 {
             });
         }
         Ok(array.value(index))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/bridge/temporal.rs
+++ b/src/bridge/temporal.rs
@@ -130,10 +130,6 @@ impl<U: TimeUnitSpec + 'static> ArrowBindingView for Timestamp<U> {
         }
         Ok(Timestamp::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Marker describing a timestamp timezone.
@@ -214,10 +210,6 @@ impl<U: TimeUnitSpec + 'static, Z: TimeZoneSpec + 'static> ArrowBindingView for 
         }
         Ok(TimestampTz::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 // ---------- Date32 / Date64 ----------
@@ -288,10 +280,6 @@ impl ArrowBindingView for Date32 {
         }
         Ok(Date32::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Milliseconds since UNIX epoch.
@@ -359,10 +347,6 @@ impl ArrowBindingView for Date64 {
             });
         }
         Ok(Date64::new(array.value(index)))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -458,10 +442,6 @@ where
         }
         Ok(Time32::new(array.value(index)))
     }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
-    }
 }
 
 /// Marker mapping for `Time64` units to Arrow time types.
@@ -553,10 +533,6 @@ where
             });
         }
         Ok(Time64::new(array.value(index)))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }
 
@@ -663,9 +639,5 @@ where
             });
         }
         Ok(Duration::new(array.value(index)))
-    }
-
-    fn is_null(array: &Self::Array, index: usize) -> bool {
-        array.is_null(index)
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,6 +10,108 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema};
 
+/// Error type for schema validation failures when creating views from RecordBatch.
+#[derive(Debug, Clone)]
+pub struct SchemaError {
+    /// Human-readable error message
+    pub message: String,
+}
+
+impl SchemaError {
+    /// Create a new schema error
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Schema validation error: {}", self.message)
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+/// Error type for view access failures when reading from Arrow arrays.
+#[cfg(feature = "views")]
+#[derive(Debug, Clone)]
+pub enum ViewAccessError {
+    /// Index out of bounds
+    OutOfBounds {
+        /// The invalid index
+        index: usize,
+        /// The array length
+        len: usize,
+        /// Optional field name for context
+        field_name: Option<&'static str>,
+    },
+    /// Unexpected null value
+    UnexpectedNull {
+        /// The index where null was found
+        index: usize,
+        /// Optional field name for context
+        field_name: Option<&'static str>,
+    },
+    /// Type mismatch during array downcast
+    TypeMismatch {
+        /// Expected type name
+        expected: String,
+        /// Actual data type
+        actual: String,
+        /// Optional field name for context
+        field_name: Option<&'static str>,
+    },
+}
+
+#[cfg(feature = "views")]
+impl std::fmt::Display for ViewAccessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutOfBounds {
+                index,
+                len,
+                field_name,
+            } => {
+                write!(f, "index {index} out of bounds (len {len})")?;
+                if let Some(name) = field_name {
+                    write!(f, " for field '{name}'")?;
+                }
+                Ok(())
+            }
+            Self::UnexpectedNull { index, field_name } => {
+                write!(f, "unexpected null at index {index}")?;
+                if let Some(name) = field_name {
+                    write!(f, " for field '{name}'")?;
+                }
+                Ok(())
+            }
+            Self::TypeMismatch {
+                expected,
+                actual,
+                field_name,
+            } => {
+                write!(f, "type mismatch: expected {expected}, got {actual}")?;
+                if let Some(name) = field_name {
+                    write!(f, " for field '{name}'")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(feature = "views")]
+impl std::error::Error for ViewAccessError {}
+
+#[cfg(feature = "views")]
+impl From<ViewAccessError> for SchemaError {
+    fn from(err: ViewAccessError) -> Self {
+        SchemaError::new(format!("View access error: {}", err))
+    }
+}
+
 /// A record (row) with a fixed, compile-time number of columns.
 pub trait Record {
     /// Number of columns in this record.
@@ -166,4 +268,107 @@ pub trait AppendStructRef {
     /// Append this struct's child values into the provided `StructBuilder` using borrows.
     /// Caller is responsible for setting the parent validity via `append(true)`.
     fn append_borrowed_into(&self, b: &mut StructBuilder);
+}
+
+/// Trait for creating zero-copy views over a RecordBatch.
+///
+/// Implemented automatically by `#[derive(Record)]` to generate a view struct
+/// (`{Name}View<'a>`) and an iterator (`{Name}Views<'a>`) that provide borrowed
+/// access to RecordBatch rows without copying data.
+#[cfg(feature = "views")]
+pub trait FromRecordBatch: Record + Sized {
+    /// The view type representing a single row with borrowed references.
+    type View<'a>;
+
+    /// The iterator type yielding Result-wrapped views over all rows.
+    ///
+    /// Each item is a `Result<View, ViewAccessError>` to handle potential errors
+    /// during view access (e.g., type mismatches, unexpected nulls, out of bounds).
+    type Views<'a>: Iterator<Item = Result<Self::View<'a>, ViewAccessError>>;
+
+    /// Create an iterator of views over the RecordBatch rows.
+    ///
+    /// # Errors
+    /// Returns `SchemaError` if the RecordBatch schema doesn't match this Record's schema.
+    /// This includes mismatched column names, types, or field counts.
+    fn from_record_batch(batch: &RecordBatch) -> Result<Self::Views<'_>, SchemaError>;
+}
+
+/// Extension trait providing convenience methods for iterators over `Result<T, ViewAccessError>`.
+///
+/// This trait is automatically implemented for any iterator yielding `Result<T, ViewAccessError>`,
+/// such as the iterators returned by [`FromRecordBatch::from_record_batch`].
+#[cfg(feature = "views")]
+pub trait ViewResultIteratorExt: Iterator + Sized {
+    /// The success type of the Result items.
+    type Item;
+
+    /// Flatten the Result iterator, returning all views or the first error.
+    ///
+    /// This consumes the iterator and returns a `Result` containing either:
+    /// - `Ok(Vec<T>)` with all successfully accessed views
+    /// - `Err(ViewAccessError)` with the first error encountered
+    ///
+    /// # Errors
+    /// Returns the first `ViewAccessError` encountered while iterating.
+    ///
+    /// # Example
+    /// ```
+    /// use typed_arrow::prelude::*;
+    ///
+    /// #[derive(typed_arrow::Record)]
+    /// struct Row {
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// # let rows = vec![Row { id: 1, name: "Alice".into() }];
+    /// # let mut b = <Row as BuildRows>::new_builders(1);
+    /// # b.append_rows(rows);
+    /// # let batch = b.finish().into_record_batch();
+    /// // Returns all views or first error
+    /// let views = batch.iter_views::<Row>()?.try_flatten()?;
+    /// for row in views {
+    ///     println!("{}: {}", row.id, row.name);
+    /// }
+    /// # Ok::<_, typed_arrow::schema::SchemaError>(())
+    /// ```
+    fn try_flatten(self) -> Result<Vec<<Self as ViewResultIteratorExt>::Item>, ViewAccessError>
+    where
+        Result<Vec<<Self as ViewResultIteratorExt>::Item>, ViewAccessError>:
+            std::iter::FromIterator<<Self as Iterator>::Item>,
+    {
+        self.collect()
+    }
+}
+
+#[cfg(feature = "views")]
+impl<I, T> ViewResultIteratorExt for I
+where
+    I: Iterator<Item = Result<T, ViewAccessError>>,
+{
+    type Item = T;
+}
+
+/// Trait for creating a view from a StructArray at a specific index.
+///
+/// This is automatically implemented by `#[derive(Record)]` and used internally
+/// to support nested struct views.
+#[cfg(feature = "views")]
+pub trait StructView: Record + Sized {
+    /// The view type for this struct with borrowed references.
+    type View<'a>;
+
+    /// Extract a view at the given index from a StructArray.
+    ///
+    /// # Errors
+    /// Returns `ViewAccessError` if the index is out of bounds, the value is null when expected to
+    /// be non-null, or if there's a type mismatch during field extraction.
+    fn view_at(
+        array: &arrow_array::StructArray,
+        index: usize,
+    ) -> Result<Self::View<'_>, ViewAccessError>;
+
+    /// Check if the struct value at the given index is null.
+    fn is_null_at(array: &arrow_array::StructArray, index: usize) -> bool;
 }

--- a/tests/record_batch_views.rs
+++ b/tests/record_batch_views.rs
@@ -1,0 +1,176 @@
+use arrow_array::RecordBatch;
+use typed_arrow::prelude::*;
+
+#[derive(typed_arrow::Record)]
+struct SimpleRecord {
+    id: i64,
+    name: String,
+    score: f32,
+    active: Option<bool>,
+}
+
+#[test]
+fn test_simple_record_batch_views() -> Result<(), SchemaError> {
+    // Build rows
+    let rows = vec![
+        SimpleRecord {
+            id: 1,
+            name: "alice".into(),
+            score: 10.5,
+            active: Some(true),
+        },
+        SimpleRecord {
+            id: 2,
+            name: "bob".into(),
+            score: 20.0,
+            active: None,
+        },
+        SimpleRecord {
+            id: 3,
+            name: "carol".into(),
+            score: 30.25,
+            active: Some(false),
+        },
+    ];
+
+    // Build RecordBatch
+    let mut b = <SimpleRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    // Create views iterator using convenient API
+    let views = batch.iter_views::<SimpleRecord>()?;
+
+    // Collect all views using the convenience method
+    let collected = views.try_flatten()?;
+    assert_eq!(collected.len(), 3);
+
+    // Check first row
+    assert_eq!(collected[0].id, 1);
+    assert_eq!(collected[0].name, "alice");
+    assert_eq!(collected[0].score, 10.5);
+    assert_eq!(collected[0].active, Some(true));
+
+    // Check second row
+    assert_eq!(collected[1].id, 2);
+    assert_eq!(collected[1].name, "bob");
+    assert_eq!(collected[1].score, 20.0);
+    assert_eq!(collected[1].active, None);
+
+    // Check third row
+    assert_eq!(collected[2].id, 3);
+    assert_eq!(collected[2].name, "carol");
+    assert_eq!(collected[2].score, 30.25);
+    assert_eq!(collected[2].active, Some(false));
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Record)]
+struct Address {
+    city: String,
+    zip: Option<i32>,
+}
+
+#[derive(typed_arrow::Record)]
+struct Person {
+    id: i64,
+    address: Option<Address>,
+    email: Option<String>,
+}
+
+#[test]
+fn test_nested_record_batch_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        Person {
+            id: 1,
+            address: Some(Address {
+                city: "NYC".into(),
+                zip: None,
+            }),
+            email: Some("a@example.com".into()),
+        },
+        Person {
+            id: 2,
+            address: None,
+            email: None,
+        },
+        Person {
+            id: 3,
+            address: Some(Address {
+                city: "SF".into(),
+                zip: Some(94111),
+            }),
+            email: Some("c@example.com".into()),
+        },
+    ];
+
+    // Build RecordBatch
+    let mut b = <Person as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    // Create views iterator
+    let views = batch.iter_views::<Person>()?;
+
+    let collected = views.try_flatten()?;
+    assert_eq!(collected.len(), 3);
+
+    // Check first row with nested struct
+    assert_eq!(collected[0].id, 1);
+    assert!(collected[0].address.is_some());
+    let addr = collected[0].address.as_ref().unwrap();
+    assert_eq!(addr.city, "NYC");
+    assert_eq!(addr.zip, None);
+    assert_eq!(collected[0].email, Some("a@example.com"));
+
+    // Check second row with null nested struct
+    assert_eq!(collected[1].id, 2);
+    assert!(collected[1].address.is_none());
+    assert_eq!(collected[1].email, None);
+
+    // Check third row
+    assert_eq!(collected[2].id, 3);
+    assert!(collected[2].address.is_some());
+    let addr = collected[2].address.as_ref().unwrap();
+    assert_eq!(addr.city, "SF");
+    assert_eq!(addr.zip, Some(94111));
+    assert_eq!(collected[2].email, Some("c@example.com"));
+
+    Ok(())
+}
+
+#[test]
+fn test_iterator_properties() -> Result<(), SchemaError> {
+    let rows = vec![
+        SimpleRecord {
+            id: 1,
+            name: "test".into(),
+            score: 1.0,
+            active: Some(true),
+        },
+        SimpleRecord {
+            id: 2,
+            name: "test2".into(),
+            score: 2.0,
+            active: None,
+        },
+    ];
+
+    let mut b = <SimpleRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = batch.iter_views::<SimpleRecord>()?;
+
+    // Test size_hint
+    assert_eq!(views.size_hint(), (2, Some(2)));
+
+    // Test ExactSizeIterator
+    assert_eq!(views.len(), 2);
+
+    Ok(())
+}

--- a/tests/record_batch_views_comprehensive.rs
+++ b/tests/record_batch_views_comprehensive.rs
@@ -1,0 +1,105 @@
+// Comprehensive test showing all view types working together
+
+use arrow_array::RecordBatch;
+use typed_arrow::{
+    bridge::{Dictionary, List, Map},
+    prelude::*,
+};
+
+#[derive(typed_arrow::Union)]
+enum Status {
+    Active(i32),
+    Inactive(String),
+}
+
+#[test]
+fn test_all_view_types_together() -> Result<(), typed_arrow::schema::SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct ComplexRow {
+        // Primitives
+        id: i64,
+        score: f64,
+
+        // Strings
+        name: String,
+
+        // Dictionary
+        category: Dictionary<i32, String>,
+
+        // List
+        tags: List<String>,
+
+        // Map
+        metadata: Map<String, i32>,
+
+        // Union
+        status: Status,
+    }
+
+    let rows = vec![
+        ComplexRow {
+            id: 1,
+            score: 95.5,
+            name: "Alice".to_string(),
+            category: Dictionary::new("premium".to_string()),
+            tags: List::new(vec!["rust".to_string(), "arrow".to_string()]),
+            metadata: Map::new(vec![("views".to_string(), 100), ("likes".to_string(), 50)]),
+            status: Status::Active(42),
+        },
+        ComplexRow {
+            id: 2,
+            score: 87.3,
+            name: "Bob".to_string(),
+            category: Dictionary::new("standard".to_string()),
+            tags: List::new(vec!["python".to_string()]),
+            metadata: Map::new(vec![("views".to_string(), 200)]),
+            status: Status::Inactive("on vacation".to_string()),
+        },
+    ];
+
+    // Build RecordBatch
+    let mut b = <ComplexRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    // Iterate over views using convenient API
+    let views = batch.iter_views::<ComplexRow>()?;
+
+    for (idx, row) in views.enumerate() {
+        let row = row.unwrap();
+        if idx == 0 {
+            // Verify row 1
+            assert_eq!(row.id, 1);
+            assert!((row.score - 95.5).abs() < 0.001);
+            assert_eq!(row.name, "Alice");
+            assert_eq!(row.category, "premium");
+
+            let tags0: Vec<_> = row.tags.map(|r| r.unwrap()).collect();
+            assert_eq!(tags0, vec!["rust", "arrow"]);
+
+            let metadata0: Vec<_> = row.metadata.map(|r| r.unwrap()).collect();
+            assert_eq!(metadata0.len(), 2);
+
+            match row.status {
+                StatusView::Active(v) => assert_eq!(v, 42),
+                _ => panic!("expected Active"),
+            }
+        } else if idx == 1 {
+            // Verify row 2
+            assert_eq!(row.id, 2);
+            assert_eq!(row.name, "Bob");
+            assert_eq!(row.category, "standard");
+
+            let tags1: Vec<_> = row.tags.map(|r| r.unwrap()).collect();
+            assert_eq!(tags1, vec!["python"]);
+
+            match row.status {
+                StatusView::Inactive(v) => assert_eq!(v, "on vacation"),
+                _ => panic!("expected Inactive"),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tests/record_batch_views_dictionary.rs
+++ b/tests/record_batch_views_dictionary.rs
@@ -1,0 +1,81 @@
+use arrow_array::RecordBatch;
+use typed_arrow::{bridge::Dictionary, prelude::*};
+
+#[test]
+fn test_dictionary_string_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        category: Dictionary<i32, String>,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            category: Dictionary::new("apple".to_string()),
+        },
+        TestRow {
+            id: 2,
+            category: Dictionary::new("banana".to_string()),
+        },
+        TestRow {
+            id: 3,
+            category: Dictionary::new("apple".to_string()), // Repeated value
+        },
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let expected = [(1, "apple"), (2, "banana"), (3, "apple")];
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    for (idx, row_view) in views.enumerate() {
+        let row_view = row_view.unwrap();
+        assert_eq!(row_view.id, expected[idx].0);
+        assert_eq!(row_view.category, expected[idx].1);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_dictionary_primitive_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        code: Dictionary<i16, i64>,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            code: Dictionary::new(100),
+        },
+        TestRow {
+            id: 2,
+            code: Dictionary::new(200),
+        },
+        TestRow {
+            id: 3,
+            code: Dictionary::new(100), // Repeated
+        },
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let expected = [(1, 100), (2, 200), (3, 100)];
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    for (idx, row_view) in views.enumerate() {
+        let row_view = row_view.unwrap();
+        assert_eq!(row_view.id, expected[idx].0);
+        assert_eq!(row_view.code, expected[idx].1);
+    }
+    Ok(())
+}

--- a/tests/record_batch_views_lists.rs
+++ b/tests/record_batch_views_lists.rs
@@ -1,0 +1,226 @@
+use arrow_array::RecordBatch;
+use typed_arrow::{prelude::*, FixedSizeList, LargeList, List};
+
+#[derive(typed_arrow::Record)]
+struct ListRecord {
+    id: i64,
+    values: List<i32>,
+}
+
+#[test]
+fn test_list_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        ListRecord {
+            id: 1,
+            values: List::new(vec![1, 2, 3]),
+        },
+        ListRecord {
+            id: 2,
+            values: List::new(vec![4, 5]),
+        },
+    ];
+
+    let mut b = <ListRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <ListRecord as FromRecordBatch>::from_record_batch(&batch)?;
+
+    // Check first row
+    let first = views.next().unwrap().unwrap();
+    assert_eq!(first.id, 1);
+
+    let first_values: Vec<i32> = first.values.map(|r| r.unwrap()).collect();
+    assert_eq!(first_values, vec![1, 2, 3]);
+
+    // Check second row
+    let second = views.next().unwrap().unwrap();
+    assert_eq!(second.id, 2);
+
+    let second_values: Vec<i32> = second.values.map(|r| r.unwrap()).collect();
+    assert_eq!(second_values, vec![4, 5]);
+
+    assert!(views.next().is_none());
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Record)]
+struct ListNullableRecord {
+    id: i64,
+    nullable_values: List<Option<i32>>,
+}
+
+#[test]
+fn test_list_nullable_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        ListNullableRecord {
+            id: 1,
+            nullable_values: List::new(vec![Some(10), None, Some(30)]),
+        },
+        ListNullableRecord {
+            id: 2,
+            nullable_values: List::new(vec![Some(40), Some(50)]),
+        },
+    ];
+
+    let mut b = <ListNullableRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <ListNullableRecord as FromRecordBatch>::from_record_batch(&batch)?;
+
+    // Check first row
+    let first = views.next().unwrap().unwrap();
+    assert_eq!(first.id, 1);
+
+    let first_nullable: Vec<Option<i32>> = first.nullable_values.map(|r| r.unwrap()).collect();
+    assert_eq!(first_nullable, vec![Some(10), None, Some(30)]);
+
+    // Check second row
+    let second = views.next().unwrap().unwrap();
+    assert_eq!(second.id, 2);
+
+    let second_nullable: Vec<Option<i32>> = second.nullable_values.map(|r| r.unwrap()).collect();
+    assert_eq!(second_nullable, vec![Some(40), Some(50)]);
+
+    assert!(views.next().is_none());
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Record)]
+struct FixedSizeListRecord {
+    id: i64,
+    coordinates: FixedSizeList<f64, 3>,
+}
+
+#[test]
+fn test_fixed_size_list_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        FixedSizeListRecord {
+            id: 1,
+            coordinates: FixedSizeList::new([1.0, 2.0, 3.0]),
+        },
+        FixedSizeListRecord {
+            id: 2,
+            coordinates: FixedSizeList::new([4.0, 5.0, 6.0]),
+        },
+    ];
+
+    let mut b = <FixedSizeListRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <FixedSizeListRecord as FromRecordBatch>::from_record_batch(&batch)?;
+
+    // Check first row
+    let first = views.next().unwrap().unwrap();
+    assert_eq!(first.id, 1);
+    let first_coords: Vec<f64> = first.coordinates.map(|r| r.unwrap()).collect();
+    assert_eq!(first_coords, vec![1.0, 2.0, 3.0]);
+
+    // Check second row
+    let second = views.next().unwrap().unwrap();
+    assert_eq!(second.id, 2);
+    let second_coords: Vec<f64> = second.coordinates.map(|r| r.unwrap()).collect();
+    assert_eq!(second_coords, vec![4.0, 5.0, 6.0]);
+
+    assert!(views.next().is_none());
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Record)]
+struct LargeListRecord {
+    id: i64,
+    large_values: LargeList<String>,
+}
+
+#[test]
+fn test_large_list_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        LargeListRecord {
+            id: 1,
+            large_values: LargeList::new(vec!["hello".to_string(), "world".to_string()]),
+        },
+        LargeListRecord {
+            id: 2,
+            large_values: LargeList::new(vec!["foo".to_string()]),
+        },
+    ];
+
+    let mut b = <LargeListRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <LargeListRecord as FromRecordBatch>::from_record_batch(&batch)?;
+
+    // Check first row
+    let first = views.next().unwrap().unwrap();
+    assert_eq!(first.id, 1);
+    let first_values: Vec<&str> = first.large_values.map(|r| r.unwrap()).collect();
+    assert_eq!(first_values, vec!["hello", "world"]);
+
+    // Check second row
+    let second = views.next().unwrap().unwrap();
+    assert_eq!(second.id, 2);
+    let second_values: Vec<&str> = second.large_values.map(|r| r.unwrap()).collect();
+    assert_eq!(second_values, vec!["foo"]);
+
+    assert!(views.next().is_none());
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Record)]
+struct NestedListRecord {
+    id: i64,
+    nested: List<List<i32>>,
+}
+
+#[test]
+fn test_nested_list_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        NestedListRecord {
+            id: 1,
+            nested: List::new(vec![List::new(vec![1, 2]), List::new(vec![3, 4, 5])]),
+        },
+        NestedListRecord {
+            id: 2,
+            nested: List::new(vec![List::new(vec![6])]),
+        },
+    ];
+
+    let mut b = <NestedListRecord as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <NestedListRecord as FromRecordBatch>::from_record_batch(&batch)?;
+
+    // Check first row
+    let first = views.next().unwrap().unwrap();
+    assert_eq!(first.id, 1);
+    let first_nested: Vec<Vec<i32>> = first
+        .nested
+        .map(|inner_list| inner_list.unwrap().map(|r| r.unwrap()).collect::<Vec<_>>())
+        .collect();
+    assert_eq!(first_nested, vec![vec![1, 2], vec![3, 4, 5]]);
+
+    // Check second row
+    let second = views.next().unwrap().unwrap();
+    assert_eq!(second.id, 2);
+    let second_nested: Vec<Vec<i32>> = second
+        .nested
+        .map(|inner_list| inner_list.unwrap().map(|r| r.unwrap()).collect::<Vec<_>>())
+        .collect();
+    assert_eq!(second_nested, vec![vec![6]]);
+
+    assert!(views.next().is_none());
+    Ok(())
+}

--- a/tests/record_batch_views_maps.rs
+++ b/tests/record_batch_views_maps.rs
@@ -1,0 +1,195 @@
+use arrow_array::RecordBatch;
+use typed_arrow::{bridge::Map, prelude::*};
+
+#[test]
+fn test_map_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        tags: Map<String, i32>,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            tags: Map::new(vec![("foo".to_string(), 10), ("bar".to_string(), 20)]),
+        },
+        TestRow {
+            id: 2,
+            tags: Map::new(vec![("baz".to_string(), 30)]),
+        },
+        TestRow {
+            id: 3,
+            tags: Map::new(vec![]),
+        },
+    ];
+
+    let expected_data = [
+        (1, vec![("foo", 10), ("bar", 20)]),
+        (2, vec![("baz", 30)]),
+        (3, vec![]),
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    // Test iteration over batch views
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    for (idx, row_view) in views.enumerate() {
+        let row_view = row_view.unwrap();
+        assert_eq!(row_view.id, expected_data[idx].0);
+
+        // Collect map entries into a Vec (unwrap Result items)
+        let entries: Vec<_> = row_view.tags.map(|r| r.unwrap()).collect();
+
+        assert_eq!(entries.len(), expected_data[idx].1.len());
+        for (i, (key, val)) in entries.iter().enumerate() {
+            assert_eq!(*key, expected_data[idx].1[i].0);
+            assert_eq!(*val, expected_data[idx].1[i].1);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_map_nullable_values_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        tags: Map<String, Option<i32>>,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            tags: Map::new(vec![
+                ("foo".to_string(), Some(10)),
+                ("bar".to_string(), None),
+                ("baz".to_string(), Some(30)),
+            ]),
+        },
+        TestRow {
+            id: 2,
+            tags: Map::new(vec![("null_val".to_string(), None)]),
+        },
+    ];
+
+    let expected_data = [
+        (1, vec![("foo", Some(10)), ("bar", None), ("baz", Some(30))]),
+        (2, vec![("null_val", None)]),
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    for (idx, row_view) in views.enumerate() {
+        let row_view = row_view.unwrap();
+        assert_eq!(row_view.id, expected_data[idx].0);
+
+        let entries: Vec<_> = row_view.tags.map(|r| r.unwrap()).collect();
+
+        assert_eq!(entries.len(), expected_data[idx].1.len());
+        for (i, (key, val)) in entries.iter().enumerate() {
+            assert_eq!(*key, expected_data[idx].1[i].0);
+            assert_eq!(val, &expected_data[idx].1[i].1);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_ordered_map_views() -> Result<(), SchemaError> {
+    use std::collections::BTreeMap;
+
+    use typed_arrow::bridge::OrderedMap;
+
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        metadata: OrderedMap<String, String>,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            metadata: OrderedMap::new(BTreeMap::from([
+                ("author".to_string(), "Alice".to_string()),
+                ("version".to_string(), "1.0".to_string()),
+            ])),
+        },
+        TestRow {
+            id: 2,
+            metadata: OrderedMap::new(BTreeMap::from([("author".to_string(), "Bob".to_string())])),
+        },
+    ];
+
+    let expected_data = [
+        (1, vec![("author", "Alice"), ("version", "1.0")]),
+        (2, vec![("author", "Bob")]),
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    for (idx, row_view) in views.enumerate() {
+        let row_view = row_view.unwrap();
+        assert_eq!(row_view.id, expected_data[idx].0);
+
+        let entries: Vec<_> = row_view.metadata.map(|r| r.unwrap()).collect();
+
+        assert_eq!(entries.len(), expected_data[idx].1.len());
+        for (i, (key, val)) in entries.iter().enumerate() {
+            assert_eq!(*key, expected_data[idx].1[i].0);
+            assert_eq!(*val, expected_data[idx].1[i].1);
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_map_len_and_is_empty() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        tags: Map<String, i32>,
+    }
+
+    let rows = vec![
+        TestRow {
+            tags: Map::new(vec![
+                ("a".to_string(), 1),
+                ("b".to_string(), 2),
+                ("c".to_string(), 3),
+            ]),
+        },
+        TestRow {
+            tags: Map::new(vec![]),
+        },
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let mut views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+
+    let row0 = views.next().unwrap().unwrap();
+    assert_eq!(row0.tags.len(), 3);
+    assert!(!row0.tags.is_empty());
+
+    let row1 = views.next().unwrap().unwrap();
+    assert_eq!(row1.tags.len(), 0);
+    assert!(row1.tags.is_empty());
+    Ok(())
+}

--- a/tests/record_batch_views_temporal.rs
+++ b/tests/record_batch_views_temporal.rs
@@ -1,0 +1,54 @@
+use arrow_array::RecordBatch;
+use typed_arrow::{prelude::*, Date32, Duration, Millisecond, Second, Timestamp};
+
+#[derive(typed_arrow::Record)]
+struct Event {
+    id: i64,
+    timestamp: Timestamp<Millisecond>,
+    date: Date32,
+    duration: Option<Duration<Second>>,
+}
+
+#[test]
+fn test_temporal_views() -> Result<(), SchemaError> {
+    let rows = vec![
+        Event {
+            id: 1,
+            timestamp: Timestamp::new(1700000000000),
+            date: Date32::new(19000),
+            duration: Some(Duration::new(3600)),
+        },
+        Event {
+            id: 2,
+            timestamp: Timestamp::new(1700000100000),
+            date: Date32::new(19001),
+            duration: None,
+        },
+    ];
+
+    let mut b = <Event as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = <Event as FromRecordBatch>::from_record_batch(&batch)?;
+    let collected: Vec<_> = views.map(|r| r.unwrap()).collect();
+
+    assert_eq!(collected.len(), 2);
+
+    // Check first row
+    assert_eq!(collected[0].id, 1);
+    assert_eq!(collected[0].timestamp.value(), 1700000000000);
+    assert_eq!(collected[0].date.value(), 19000);
+    assert!(collected[0].duration.is_some());
+    if let Some(ref d) = collected[0].duration {
+        assert_eq!(d.value(), 3600);
+    }
+
+    // Check second row
+    assert_eq!(collected[1].id, 2);
+    assert_eq!(collected[1].timestamp.value(), 1700000100000);
+    assert_eq!(collected[1].date.value(), 19001);
+    assert!(collected[1].duration.is_none());
+    Ok(())
+}

--- a/tests/record_batch_views_union.rs
+++ b/tests/record_batch_views_union.rs
@@ -1,0 +1,111 @@
+use arrow_array::RecordBatch;
+use typed_arrow::prelude::*;
+
+#[derive(typed_arrow::Union)]
+enum Value {
+    I(i32),
+    S(String),
+}
+
+#[test]
+fn test_union_dense_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        value: Value,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            value: Value::I(42),
+        },
+        TestRow {
+            id: 2,
+            value: Value::S("hello".to_string()),
+        },
+        TestRow {
+            id: 3,
+            value: Value::I(99),
+        },
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    let collected: Vec<_> = views.map(|r| r.unwrap()).collect();
+
+    assert_eq!(collected.len(), 3);
+    assert_eq!(collected[0].id, 1);
+    assert_eq!(collected[1].id, 2);
+    assert_eq!(collected[2].id, 3);
+
+    // Check union values
+    match collected[0].value {
+        ValueView::I(v) => assert_eq!(v, 42),
+        _ => panic!("expected I variant"),
+    }
+
+    match collected[1].value {
+        ValueView::S(v) => assert_eq!(v, "hello"),
+        _ => panic!("expected S variant"),
+    }
+
+    match collected[2].value {
+        ValueView::I(v) => assert_eq!(v, 99),
+        _ => panic!("expected I variant"),
+    }
+
+    Ok(())
+}
+
+#[derive(typed_arrow::Union)]
+#[union(mode = "sparse")]
+enum SparseValue {
+    A(i64),
+    B(f64),
+}
+
+#[test]
+fn test_union_sparse_views() -> Result<(), SchemaError> {
+    #[derive(typed_arrow::Record)]
+    struct TestRow {
+        id: i32,
+        value: SparseValue,
+    }
+
+    let rows = vec![
+        TestRow {
+            id: 1,
+            value: SparseValue::A(100),
+        },
+        TestRow {
+            id: 2,
+            value: SparseValue::B(3.125),
+        },
+    ];
+
+    let mut b = <TestRow as BuildRows>::new_builders(rows.len());
+    b.append_rows(rows);
+    let arrays = b.finish();
+    let batch: RecordBatch = arrays.into_record_batch();
+
+    let views = <TestRow as FromRecordBatch>::from_record_batch(&batch)?;
+    let collected: Vec<_> = views.map(|r| r.unwrap()).collect();
+
+    assert_eq!(collected.len(), 2);
+
+    match collected[0].value {
+        SparseValueView::A(v) => assert_eq!(v, 100),
+        _ => panic!("expected A variant"),
+    }
+
+    match collected[1].value {
+        SparseValueView::B(v) => assert!((v - 3.125).abs() < 0.001),
+        _ => panic!("expected B variant"),
+    }
+    Ok(())
+}

--- a/typed-arrow-derive/src/union.rs
+++ b/typed-arrow-derive/src/union.rs
@@ -363,8 +363,8 @@ fn impl_union(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     .as_any()
                     .downcast_ref::<<#v_ty as ::typed_arrow::bridge::ArrowBindingView>::Array>()
                     .ok_or_else(|| ::typed_arrow::schema::ViewAccessError::TypeMismatch {
-                        expected: ::std::any::type_name::<<#v_ty as ::typed_arrow::bridge::ArrowBindingView>::Array>().to_string(),
-                        actual: format!("{:?}", child_array_ref.data_type()),
+                        expected: <#v_ty as ::typed_arrow::bridge::ArrowBinding>::data_type(),
+                        actual: child_array_ref.data_type().clone(),
                         field_name: ::core::option::Option::Some(stringify!(#v_ident)),
                     })?;
                 let value_index = if let Some(offsets) = array.offsets() {
@@ -418,17 +418,12 @@ fn impl_union(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 
                 match type_id {
                     #(#view_match_arms)*
-                    _ => ::core::result::Result::Err(::typed_arrow::schema::ViewAccessError::TypeMismatch {
-                        expected: "valid union type_id".to_string(),
-                        actual: format!("type_id {}", type_id),
-                        field_name: ::core::option::Option::None,
+                    _ => ::core::result::Result::Err(::typed_arrow::schema::ViewAccessError::OutOfBounds {
+                        index: type_id as usize,
+                        len: #n,
+                        field_name: ::core::option::Option::Some("union type_id"),
                     }),
                 }
-            }
-
-            fn is_null(array: &Self::Array, index: usize) -> bool {
-                use ::typed_arrow::arrow_array::Array;
-                array.is_null(index)
             }
         }
     };


### PR DESCRIPTION
## Motivation

The views API provides zero-copy, struct-like read access over RecordBatch data. Before this, typed-arrow only supported writing Arrow data through the `BuildRows` API - there was no (zero-copy) ergonomic way to read Parquet/Arrow files back into typed Rust structures with compile-time schema validation.

This fills a critical gap: when working with Parquet records, you often want struct-like semantics for reading data, just as you have for writing. The views API enables this by:
- Providing borrowed, zero-copy views into RecordBatch columns
- Maintaining compile-time type safety with Arrow schema validation
- Supporting all Arrow types: primitives, strings, lists, maps, structs, unions, temporal types, decimals, etc.
- Offering Result-based error handling for graceful failures

However, at ~2,500 lines of code, this is a substantial addition. Making it optional via a feature flag allows users who only need the write path to avoid the compilation and binary size overhead, while keeping it enabled by default for backward compatibility.

## Summary
- Added `views` feature flag (enabled by default) to make the RecordBatch views API optional
- Gated all view-related traits (`ArrowBindingView`, `FromRecordBatch`, `StructView`, etc.) with `#[cfg(feature = "views")]`
- Gated view implementations across all bridge types (primitives, strings, lists, maps, temporal, etc.)
- Updated derive macros to conditionally generate view code only when the feature is enabled
- Updated tests and examples with `required-features = ["views"]`
- Split imports to conditionally import view-related types

Users can now disable views with `--no-default-features --features derive` for a leaner build.

## Test plan
- [x] Build succeeds with views feature enabled (default)
- [x] Build succeeds with views feature disabled (`--no-default-features --features derive`)
- [x] All tests pass with views feature enabled
- [x] Clippy passes with no warnings
- [x] Code formatted with rustfmt
