### PR TITLE
feat(collections): implement Clone and Debug for collection types

### DIFF
--- a/src/bridge/lists.rs
+++ b/src/bridge/lists.rs
@@ -13,6 +13,19 @@ use super::ArrowBindingView;
 /// - List-level nullability: wrap the column in `Option<List<T>>`.
 /// - Item-level nullability: use `List<Option<T>>` when elements can be null.
 pub struct List<T>(Vec<T>);
+
+impl<T: Clone> Clone for List<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for List<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("List").field(&self.0).finish()
+    }
+}
+
 impl<T> List<T> {
     /// Construct a new list from a vector of values.
     #[inline]
@@ -424,6 +437,19 @@ where
 
 /// Wrapper denoting an Arrow `FixedSizeListArray` column with `N` elements of `T`.
 pub struct FixedSizeList<T, const N: usize>([T; N]);
+
+impl<T: Clone, const N: usize> Clone for FixedSizeList<T, N> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: std::fmt::Debug, const N: usize> std::fmt::Debug for FixedSizeList<T, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FixedSizeList").field(&self.0).finish()
+    }
+}
+
 impl<T, const N: usize> FixedSizeList<T, N> {
     /// Construct a new fixed-size list from an array of length `N`.
     #[inline]
@@ -635,6 +661,21 @@ where
 
 /// Wrapper denoting a `FixedSizeListArray` with `N` elements where items are nullable.
 pub struct FixedSizeListNullable<T, const N: usize>([Option<T>; N]);
+
+impl<T: Clone, const N: usize> Clone for FixedSizeListNullable<T, N> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: std::fmt::Debug, const N: usize> std::fmt::Debug for FixedSizeListNullable<T, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FixedSizeListNullable")
+            .field(&self.0)
+            .finish()
+    }
+}
+
 impl<T, const N: usize> FixedSizeListNullable<T, N> {
     /// Construct a new fixed-size list with nullable items from an array of length `N`.
     #[inline]
@@ -859,6 +900,19 @@ where
 
 /// Wrapper denoting an Arrow `LargeListArray` column with elements of `T`.
 pub struct LargeList<T>(Vec<T>);
+
+impl<T: Clone> Clone for LargeList<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for LargeList<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("LargeList").field(&self.0).finish()
+    }
+}
+
 impl<T> LargeList<T> {
     /// Construct a new large-list from a vector of values.
     #[inline]

--- a/src/bridge/map.rs
+++ b/src/bridge/map.rs
@@ -13,6 +13,21 @@ use super::ArrowBinding;
 /// - Values are non-nullable for `Map<K, V, SORTED>` and nullable for `Map<K, Option<V>, SORTED>`.
 /// - Column-level nullability is expressed with `Option<Map<...>>`.
 pub struct Map<K, V, const SORTED: bool = false>(Vec<(K, V)>);
+
+impl<K: Clone, V: Clone, const SORTED: bool> Clone for Map<K, V, SORTED> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<K: std::fmt::Debug, V: std::fmt::Debug, const SORTED: bool> std::fmt::Debug
+    for Map<K, V, SORTED>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Map").field(&self.0).finish()
+    }
+}
+
 impl<K, V, const SORTED: bool> Map<K, V, SORTED> {
     /// Construct a new map from a vector of `(key, value)` pairs.
     #[inline]
@@ -129,6 +144,19 @@ where
 /// Keys are non-nullable; the value field is nullable per `MapBuilder` semantics, but this
 /// wrapper does not write null values.
 pub struct OrderedMap<K, V>(BTreeMap<K, V>);
+
+impl<K: Clone, V: Clone> Clone for OrderedMap<K, V> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<K: std::fmt::Debug, V: std::fmt::Debug> std::fmt::Debug for OrderedMap<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OrderedMap").field(&self.0).finish()
+    }
+}
+
 impl<K, V> OrderedMap<K, V> {
     /// Construct a new ordered-map from a `BTreeMap` (keys sorted).
     #[inline]


### PR DESCRIPTION
Adds `Clone` and `Debug` trait implementations for all collection wrapper types `<T>`, where `T` implements each.

## Changes

- Implement `Clone` for:
  - `List<T>`
  - `FixedSizeList<T, N>`
  - `FixedSizeListNullable<T, N>`
  - `LargeList<T>`
  - `Map<K, V, SORTED>`
  - `OrderedMap<K, V>`

- Implement `Debug` for all the above types

