### PR TITLE
fix(typed-arrow-derive): guard views cfg from leaking to dependents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ repository = { workspace = true }
 default = ["derive", "views"]
 derive = ["dep:typed-arrow-derive"]
 ext-hooks = ["derive", "typed-arrow-derive/ext-hooks"]
-views = ["derive"]
+views = ["derive", "typed-arrow-derive/views"]
 
 [dependencies]
 typed-arrow-derive = { workspace = true, optional = true }

--- a/typed-arrow-derive/Cargo.toml
+++ b/typed-arrow-derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [features]
 ext-hooks = []
+views = []
 
 [dependencies]
 proc-macro2 = "1"


### PR DESCRIPTION
- Added a no-op views feature to `typed-arrow-derive` and wired the top-level views feature to enable it, so the macro crate knows when to generate view support.
- Reworked view-related expansions in the derive macros to emit code only while the macro crate’s views feature is active, preventing any `#[cfg(feature = "views")]` tokens from leaking into user crates and triggering unexpected cfg warnings.