### PR TITLE
chore(typed-arrow-dyn): Add Debug derive for major structs

### DIFF
--- a/typed-arrow-dyn/src/dyn_builder.rs
+++ b/typed-arrow-dyn/src/dyn_builder.rs
@@ -8,6 +8,7 @@ use arrow_schema::DataType;
 use crate::{cell::DynCell, DynError};
 
 /// Result of finishing a dynamic column builder.
+#[derive(Debug)]
 pub struct FinishedColumn {
     pub array: ArrayRef,
     /// Metadata describing union arrays encountered in this subtree.

--- a/typed-arrow-dyn/src/schema.rs
+++ b/typed-arrow-dyn/src/schema.rs
@@ -8,7 +8,7 @@ use arrow_schema::{Schema, SchemaRef};
 use crate::{DynRowView, DynRowViews, DynViewError};
 
 /// A runtime Arrow schema wrapper used by the unified facade.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynSchema {
     /// The underlying `arrow_schema::SchemaRef`.
     pub schema: SchemaRef,

--- a/typed-arrow-dyn/src/view.rs
+++ b/typed-arrow-dyn/src/view.rs
@@ -505,7 +505,7 @@ impl std::fmt::Debug for DynCellRaw {
 }
 
 /// Lifetime-erased struct view backing a [`DynCellRaw::Struct`] cell.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynStructViewRaw {
     array: NonNull<StructArray>,
     fields: Fields,
@@ -552,7 +552,7 @@ impl DynStructViewRaw {
 }
 
 /// Lifetime-erased list view backing a [`DynCellRaw::List`] cell.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynListViewRaw {
     values: ArrayRef,
     item_field: FieldRef,
@@ -605,7 +605,7 @@ impl DynListViewRaw {
 
 /// Lifetime-erased fixed-size list view backing a [`DynCellRaw::FixedSizeList`] cell.
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynFixedSizeListViewRaw {
     values: ArrayRef,
     item_field: FieldRef,
@@ -657,7 +657,7 @@ impl DynFixedSizeListViewRaw {
 }
 
 /// Lifetime-erased map view backing a [`DynCellRaw::Map`] cell.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynMapViewRaw {
     array: NonNull<MapArray>,
     start: usize,
@@ -703,7 +703,7 @@ impl DynMapViewRaw {
 }
 
 /// Lifetime-erased union view backing a [`DynCellRaw::Union`] cell.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynUnionViewRaw {
     array: NonNull<UnionArray>,
     fields: UnionFields,
@@ -759,6 +759,7 @@ fn non_null_from_bytes(bytes: &[u8]) -> NonNull<u8> {
 }
 
 /// Iterator over borrowed dynamic rows.
+#[derive(Debug)]
 pub struct DynRowViews<'a> {
     batch: &'a RecordBatch,
     fields: Fields,
@@ -855,6 +856,7 @@ impl<'a> Iterator for DynRowViews<'a> {
 impl<'a> ExactSizeIterator for DynRowViews<'a> {}
 
 /// Borrowed dynamic row backed by an `arrow_array::RecordBatch`.
+#[derive(Debug)]
 pub struct DynRowView<'a> {
     batch: &'a RecordBatch,
     fields: Fields,
@@ -1253,7 +1255,7 @@ mod tests {
 }
 
 /// Column projection descriptor used to derive projected dynamic views.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DynProjection(Arc<DynProjectionData>);
 
 #[derive(Debug)]


### PR DESCRIPTION
## What does PR do
* Adding debug trait can help downstream consumer to derive Debug trait

## Tests
`cargo build`