### PR TITLE
feat(views): Add From<TryFromSliceError> to enable List<[T; N]>

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,3 +105,13 @@ impl From<core::convert::Infallible> for ViewAccessError {
         match x {}
     }
 }
+
+/// Conversion from `TryFromSliceError` to allow fixed-size arrays like `[u8; N]` to work with
+/// generic List/Map implementations. This error occurs when converting `&[T]` to `[T; N]` and
+/// the slice length doesn't match the array length.
+#[cfg(feature = "views")]
+impl From<std::array::TryFromSliceError> for ViewAccessError {
+    fn from(e: std::array::TryFromSliceError) -> Self {
+        ViewAccessError::Custom(Box::new(e))
+    }
+}


### PR DESCRIPTION
Enable fixed-size arrays like `[u8; N]` to work seamlessly with List, Map, and other generic container types that use the view conversion pattern.

Previously, while fixed-size arrays implement `ArrowBindingView`, they couldn't be used as List elements because the stdlib's `TryFrom<&[T]> for [T; N]` produces `TryFromSliceError`, which didn't implement `Into<ViewAccessError>`. This prevented the generic `TryFrom<ListView<T>>` implementation from accepting fixed-size arrays.

Example usage now supported:
```rust
#[derive(typed_arrow::Record)]
struct Data {
   // Works for any [T; N] where T: Copy
   hashes: typed_arrow::List<[u8; 32]>,
}
```