### PR TITLE
jiff::Timestamp should be mapped to a UTC datetime

### DIFF
--- a/src/bridge/temporal.rs
+++ b/src/bridge/temporal.rs
@@ -665,8 +665,7 @@ impl ArrowBinding for jiff::Timestamp {
     }
 
     fn new_builder(capacity: usize) -> Self::Builder {
-        PrimitiveBuilder::<TimestampMicrosecondType>::with_capacity(capacity)
-            .with_timezone("UTC")
+        PrimitiveBuilder::<TimestampMicrosecondType>::with_capacity(capacity).with_timezone("UTC")
     }
 
     fn append_value(b: &mut Self::Builder, v: &Self) {

--- a/src/bridge/temporal.rs
+++ b/src/bridge/temporal.rs
@@ -661,11 +661,12 @@ impl ArrowBinding for jiff::Timestamp {
     type Array = PrimitiveArray<TimestampMicrosecondType>;
 
     fn data_type() -> DataType {
-        DataType::Timestamp(TimeUnit::Microsecond, None)
+        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
     }
 
     fn new_builder(capacity: usize) -> Self::Builder {
         PrimitiveBuilder::<TimestampMicrosecondType>::with_capacity(capacity)
+            .with_timezone("UTC")
     }
 
     fn append_value(b: &mut Self::Builder, v: &Self) {


### PR DESCRIPTION
In #65, I added support for jiff timestamps, where they were mapped to timezone-naïve datetimes in Arrow. However, I now realize that they should have been mapped to timezone-aware timestamps, and indeed the [documentation](https://docs.rs/jiff/latest/jiff/struct.Timestamp.html) is clear that timestamps are meant to be considered as UTC. Therefore, this PR changes the implementation of `ArrowBinding` for `jiff::Timestamp` to reflect this. Note: this is a breaking change (although I doubt anyone besides me will be affected...) and so should require a version bump to 0.7.