### PR TITLE
Support arrow 58 & bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-buffer"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +162,18 @@ name = "arrow-buffer"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2819d893750cb3380ab31ebdc8c68874dd4429f90fd09180f3c93538bd21626"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
 dependencies = [
  "bytes",
  "half",
@@ -250,6 +280,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +334,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "flatbuffers",
+]
+
+[[package]]
 name = "arrow-ord"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +377,12 @@ name = "arrow-schema"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27609cd7dd45f006abae27995c2729ef6f4b9361cde1ddd019dc31a5aa017e0"
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 
 [[package]]
 name = "arrow-select"
@@ -360,6 +423,20 @@ dependencies = [
  "arrow-buffer 57.1.0",
  "arrow-data 57.1.0",
  "arrow-schema 57.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "num-traits",
 ]
 
@@ -967,23 +1044,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "marrow"
-version = "0.2.5"
+name = "lz4_flex"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea734fcb7619dfcc47a396f7bf0c72571ccc8c18ae7236ae028d485b27424b74"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "marrow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5240d6977234968ff9ad254bfa73aa397fb51e41dcb22b1eb85835e9295485b"
 dependencies = [
  "arrow-array 55.2.0",
  "arrow-array 56.2.0",
  "arrow-array 57.1.0",
+ "arrow-array 58.1.0",
  "arrow-buffer 55.2.0",
  "arrow-buffer 56.2.0",
  "arrow-buffer 57.1.0",
+ "arrow-buffer 58.1.0",
  "arrow-data 55.2.0",
  "arrow-data 56.2.0",
  "arrow-data 57.1.0",
+ "arrow-data 58.1.0",
  "arrow-schema 55.2.0",
  "arrow-schema 56.2.0",
  "arrow-schema 57.1.0",
+ "arrow-schema 58.1.0",
  "bytemuck",
  "half",
  "serde",
@@ -1201,6 +1291,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,16 +1505,18 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.13.7"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038967a6dda16f5c6ca5b6e1afec9cd2361d39f0db681ca338ac5f0ccece6469"
+checksum = "2784e59a0315568e850cb01ddadf458f8c09e28d8cfc4880c2cc08f5dc3444e0"
 dependencies = [
  "arrow-array 55.2.0",
  "arrow-array 56.2.0",
  "arrow-array 57.1.0",
+ "arrow-array 58.1.0",
  "arrow-schema 55.2.0",
  "arrow-schema 56.2.0",
  "arrow-schema 57.1.0",
+ "arrow-schema 58.1.0",
  "bytemuck",
  "chrono",
  "half",
@@ -1608,15 +1733,19 @@ dependencies = [
  "arrow-array 55.2.0",
  "arrow-array 56.2.0",
  "arrow-array 57.1.0",
+ "arrow-array 58.1.0",
  "arrow-buffer 55.2.0",
  "arrow-buffer 56.2.0",
  "arrow-buffer 57.1.0",
+ "arrow-buffer 58.1.0",
  "arrow-data 55.2.0",
  "arrow-data 56.2.0",
  "arrow-data 57.1.0",
+ "arrow-data 58.1.0",
  "arrow-schema 55.2.0",
  "arrow-schema 56.2.0",
  "arrow-schema 57.1.0",
+ "arrow-schema 58.1.0",
  "half",
  "jiff",
  "serde",
@@ -1653,6 +1782,7 @@ dependencies = [
  "parquet 55.2.0",
  "parquet 56.2.0",
  "parquet 57.1.0",
+ "parquet 58.1.0",
  "serde",
  "thiserror",
  "typed-arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,7 +1728,7 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-arrow"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arrow-array 55.2.0",
  "arrow-array 56.2.0",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "typed-arrow-derive"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,13 @@ arrow-57 = [
     "dep:arrow-data-57",
     "dep:arrow-schema-57",
 ]
-default = ["arrow-57", "derive", "views"]
+arrow-58 = [
+    "dep:arrow-array-58",
+    "dep:arrow-buffer-58",
+    "dep:arrow-data-58",
+    "dep:arrow-schema-58",
+]
+default = ["arrow-58", "derive", "views"]
 derive = ["dep:typed-arrow-derive"]
 ext-hooks = ["derive", "typed-arrow-derive/ext-hooks"]
 jiff = ["dep:jiff"]
@@ -54,15 +60,19 @@ serde = ["dep:serde"]
 arrow-array-55 = { package = "arrow-array", version = "55", optional = true }
 arrow-array-56 = { package = "arrow-array", version = "56", optional = true }
 arrow-array-57 = { package = "arrow-array", version = "57", optional = true }
+arrow-array-58 = { package = "arrow-array", version = "58", optional = true }
 arrow-buffer-55 = { package = "arrow-buffer", version = "55", optional = true }
 arrow-buffer-56 = { package = "arrow-buffer", version = "56", optional = true }
 arrow-buffer-57 = { package = "arrow-buffer", version = "57", optional = true }
+arrow-buffer-58 = { package = "arrow-buffer", version = "58", optional = true }
 arrow-data-55 = { package = "arrow-data", version = "55", optional = true }
 arrow-data-56 = { package = "arrow-data", version = "56", optional = true }
 arrow-data-57 = { package = "arrow-data", version = "57", optional = true }
+arrow-data-58 = { package = "arrow-data", version = "58", optional = true }
 arrow-schema-55 = { package = "arrow-schema", version = "55", optional = true }
 arrow-schema-56 = { package = "arrow-schema", version = "56", optional = true }
 arrow-schema-57 = { package = "arrow-schema", version = "57", optional = true }
+arrow-schema-58 = { package = "arrow-schema", version = "58", optional = true }
 half = { workspace = true }
 jiff = { version = "0.2", optional = true }
 serde = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ package.edition = "2024"
 package.license = "Apache-2.0"
 package.readme = "README.md"
 package.repository = "https://github.com/tonbo-io/typed-arrow"
-package.version = "0.6.1"
+package.version = "0.7.0"
 
 [workspace.dependencies]
 half = "2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-typed-arrow = { path = ".", version = "0.6.1", package = "typed-arrow", default-features = false }
-typed-arrow-derive = { path = "typed-arrow-derive", version = "0.6.1", package = "typed-arrow-derive" }
+typed-arrow = { path = ".", version = "0.7.0", package = "typed-arrow", default-features = false }
+typed-arrow-derive = { path = "typed-arrow-derive", version = "0.7.0", package = "typed-arrow-derive" }
 typed-arrow-dyn = { path = "typed-arrow-dyn", version = "0.0.7", package = "typed-arrow-dyn", default-features = false }
 
 [package]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@
 //! | `ext-hooks` | | Extensibility hooks for custom derive behavior |
 //! | `arrow-55` | | Use Arrow 55.x crates |
 //! | `arrow-56` | | Use Arrow 56.x crates |
-//! | `arrow-57` | ✓ | Use Arrow 57.x crates |
+//! | `arrow-57` | | Use Arrow 57.x crates |
+//! | `arrow-58` | ✓ | Use Arrow 58.x crates |
 //!
 //! Exactly one Arrow feature must be enabled.
 //!
@@ -229,12 +230,22 @@
 //!
 //! See `examples/12_ext_hooks.rs` for usage.
 
-#[cfg(all(feature = "arrow-55", any(feature = "arrow-56", feature = "arrow-57")))]
-compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, or arrow-57.");
-#[cfg(all(feature = "arrow-56", feature = "arrow-57"))]
-compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, or arrow-57.");
-#[cfg(not(any(feature = "arrow-55", feature = "arrow-56", feature = "arrow-57")))]
-compile_error!("Enable one Arrow feature: arrow-55, arrow-56, or arrow-57.");
+#[cfg(all(
+    feature = "arrow-55",
+    any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58")
+))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(all(feature = "arrow-56", any(feature = "arrow-57", feature = "arrow-58")))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(all(feature = "arrow-57", feature = "arrow-58"))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(not(any(
+    feature = "arrow-55",
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58"
+)))]
+compile_error!("Enable one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
 
 #[cfg(feature = "arrow-55")]
 pub extern crate arrow_array_55 as arrow_array;
@@ -242,6 +253,8 @@ pub extern crate arrow_array_55 as arrow_array;
 pub extern crate arrow_array_56 as arrow_array;
 #[cfg(feature = "arrow-57")]
 pub extern crate arrow_array_57 as arrow_array;
+#[cfg(feature = "arrow-58")]
+pub extern crate arrow_array_58 as arrow_array;
 
 #[cfg(feature = "arrow-55")]
 pub extern crate arrow_buffer_55 as arrow_buffer;
@@ -249,6 +262,8 @@ pub extern crate arrow_buffer_55 as arrow_buffer;
 pub extern crate arrow_buffer_56 as arrow_buffer;
 #[cfg(feature = "arrow-57")]
 pub extern crate arrow_buffer_57 as arrow_buffer;
+#[cfg(feature = "arrow-58")]
+pub extern crate arrow_buffer_58 as arrow_buffer;
 
 #[cfg(feature = "arrow-55")]
 pub extern crate arrow_data_55 as arrow_data;
@@ -256,6 +271,8 @@ pub extern crate arrow_data_55 as arrow_data;
 pub extern crate arrow_data_56 as arrow_data;
 #[cfg(feature = "arrow-57")]
 pub extern crate arrow_data_57 as arrow_data;
+#[cfg(feature = "arrow-58")]
+pub extern crate arrow_data_58 as arrow_data;
 
 #[cfg(feature = "arrow-55")]
 pub extern crate arrow_schema_55 as arrow_schema;
@@ -263,6 +280,8 @@ pub extern crate arrow_schema_55 as arrow_schema;
 pub extern crate arrow_schema_56 as arrow_schema;
 #[cfg(feature = "arrow-57")]
 pub extern crate arrow_schema_57 as arrow_schema;
+#[cfg(feature = "arrow-58")]
+pub extern crate arrow_schema_58 as arrow_schema;
 
 pub mod bridge;
 pub mod error;
@@ -280,7 +299,12 @@ pub mod prelude {
     pub use crate::error::ViewAccessError;
     #[cfg(feature = "views")]
     pub use crate::schema::{FromRecordBatch, ViewResultIteratorExt};
-    #[cfg(any(feature = "arrow-55", feature = "arrow-56", feature = "arrow-57"))]
+    #[cfg(any(
+        feature = "arrow-55",
+        feature = "arrow-56",
+        feature = "arrow-57",
+        feature = "arrow-58"
+    ))]
     pub use crate::{arrow_array, arrow_buffer, arrow_data, arrow_schema};
     pub use crate::{
         error::SchemaError,

--- a/typed-arrow-benches/Cargo.toml
+++ b/typed-arrow-benches/Cargo.toml
@@ -7,15 +7,16 @@ repository = { workspace = true }
 publish = false
 
 [features]
-default = ["arrow-57"]
+default = ["arrow-58"]
 arrow-55 = ["typed-arrow/arrow-55", "typed-arrow-dyn/arrow-55", "serde_arrow/arrow-55"]
 arrow-56 = ["typed-arrow/arrow-56", "typed-arrow-dyn/arrow-56", "serde_arrow/arrow-56"]
 arrow-57 = ["typed-arrow/arrow-57", "typed-arrow-dyn/arrow-57", "serde_arrow/arrow-57"]
+arrow-58 = ["typed-arrow/arrow-58", "typed-arrow-dyn/arrow-58", "serde_arrow/arrow-58"]
 
 [dependencies]
 criterion = "0.5"
 serde = { workspace = true }
-serde_arrow = { version = "0.13", default-features = false }
+serde_arrow = { version = "0.14", default-features = false }
 typed-arrow = { workspace = true, default-features = false, features = ["derive", "views"] }
 typed-arrow-dyn = { workspace = true, default-features = false }
 

--- a/typed-arrow-dyn/Cargo.toml
+++ b/typed-arrow-dyn/Cargo.toml
@@ -13,16 +13,18 @@ name = "typed_arrow_dyn"
 path = "src/lib.rs"
 
 [features]
-default = ["arrow-57"]
+default = ["arrow-58"]
 arrow-55 = ["dep:parquet-55", "typed-arrow/arrow-55"]
 arrow-56 = ["dep:parquet-56", "typed-arrow/arrow-56"]
 arrow-57 = ["dep:parquet-57", "typed-arrow/arrow-57"]
+arrow-58 = ["dep:parquet-58", "typed-arrow/arrow-58"]
 serde = ["dep:serde"]
 
 [dependencies]
 parquet-55 = { package = "parquet", version = "55", optional = true }
 parquet-56 = { package = "parquet", version = "56", optional = true }
 parquet-57 = { package = "parquet", version = "57", optional = true }
+parquet-58 = { package = "parquet", version = "58", optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 typed-arrow = { workspace = true }

--- a/typed-arrow-dyn/src/lib.rs
+++ b/typed-arrow-dyn/src/lib.rs
@@ -4,12 +4,22 @@
 //! This crate provides minimal runtime schema and builders abstractions that
 //! complement the compile-time APIs in `typed-arrow`.
 
-#[cfg(all(feature = "arrow-55", any(feature = "arrow-56", feature = "arrow-57")))]
-compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, or arrow-57.");
-#[cfg(all(feature = "arrow-56", feature = "arrow-57"))]
-compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, or arrow-57.");
-#[cfg(not(any(feature = "arrow-55", feature = "arrow-56", feature = "arrow-57")))]
-compile_error!("Enable one Arrow feature: arrow-55, arrow-56, or arrow-57.");
+#[cfg(all(
+    feature = "arrow-55",
+    any(feature = "arrow-56", feature = "arrow-57", feature = "arrow-58")
+))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(all(feature = "arrow-56", any(feature = "arrow-57", feature = "arrow-58")))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(all(feature = "arrow-57", feature = "arrow-58"))]
+compile_error!("Select exactly one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
+#[cfg(not(any(
+    feature = "arrow-55",
+    feature = "arrow-56",
+    feature = "arrow-57",
+    feature = "arrow-58"
+)))]
+compile_error!("Enable one Arrow feature: arrow-55, arrow-56, arrow-57, or arrow-58.");
 
 #[cfg(feature = "arrow-55")]
 pub use parquet_55 as parquet;
@@ -17,6 +27,8 @@ pub use parquet_55 as parquet;
 pub use parquet_56 as parquet;
 #[cfg(feature = "arrow-57")]
 pub use parquet_57 as parquet;
+#[cfg(feature = "arrow-58")]
+pub use parquet_58 as parquet;
 pub use typed_arrow::{arrow_array, arrow_buffer, arrow_data, arrow_schema};
 
 mod builders;


### PR DESCRIPTION
This commit adds a new arrow-58 feature for using the latest versions of the dependencies, and also bumps the version for release to crates.io. I've confirmed that the new version works successfully within my application.